### PR TITLE
Manifest V3 for Firefox + web-ext in build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ for Firefox.
 
 Alternatively, you can use web-ext (make sure to [have it installed](https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/)) instead of reloading manually the extension. This command will both benefit from auto-rebuilding on file changes, and from auto-reloading the extension.
 ```shell
-npm run web-ext-chrome
+npm run web-ext-chromium
 ```
-(also exists for chrome and firefox)
+(also exists for firefox)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npm run watch:firefox
 ```
 for Firefox.
 
+
 ## Loading PanierClair in Your Browser
 
 ### Chrome
@@ -60,3 +61,9 @@ for Firefox.
 - Make changes to the TypeScript files in the `src` folder.
 - The extension will automatically rebuild if you're running `npm run watch`.
 - Reload the extension in your browser to see the changes.
+
+Alternatively, you can use web-ext (make sure to [have it installed](https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/)) instead of reloading manually the extension. This command will both benefit from auto-rebuilding on file changes, and from auto-reloading the extension.
+```shell
+npm run web-ext-chrome
+```
+(also exists for chrome and firefox)

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -23,7 +23,17 @@ export default defineConfig([
     },
   },
   tseslint.configs.recommended,
- /* eslint-disable @typescript-eslint/no-explicit-any */ { files: ['**/*.md'], plugins: { markdown } as any, language: 'markdown/gfm', extends: ['markdown/recommended'] },
- /* eslint-disable @typescript-eslint/no-explicit-any */ { files: ['**/*.css'], plugins: { css } as any, language: 'css/css', extends: ['css/recommended'] }, 
+  /* eslint-disable @typescript-eslint/no-explicit-any */ {
+    files: ['**/*.md'],
+    plugins: { markdown } as any,
+    language: 'markdown/gfm',
+    extends: ['markdown/recommended'],
+  },
+  /* eslint-disable @typescript-eslint/no-explicit-any */ {
+    files: ['**/*.css'],
+    plugins: { css } as any,
+    language: 'css/css',
+    extends: ['css/recommended'],
+  },
   eslintConfigPrettier,
 ]);

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -23,7 +23,7 @@ export default defineConfig([
     },
   },
   tseslint.configs.recommended,
-  { files: ['**/*.md'], plugins: { markdown }, language: 'markdown/gfm', extends: ['markdown/recommended'] },
-  { files: ['**/*.css'], plugins: { css }, language: 'css/css', extends: ['css/recommended'] },
+ /* eslint-disable @typescript-eslint/no-explicit-any */ { files: ['**/*.md'], plugins: { markdown } as any, language: 'markdown/gfm', extends: ['markdown/recommended'] },
+ /* eslint-disable @typescript-eslint/no-explicit-any */ { files: ['**/*.css'], plugins: { css } as any, language: 'css/css', extends: ['css/recommended'] }, 
   eslintConfigPrettier,
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panierclair",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panierclair",
-      "version": "0.5.0",
+      "version": "0.5.3",
       "license": "ISC",
       "dependencies": {
         "playwright-extra": "^4.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@playwright/test": "^1.52.0",
         "@types/chrome": "^0.0.277",
         "@types/node": "^24.7.2",
+        "concurrently": "^9.2.1",
         "copy-webpack-plugin": "^12.0.2",
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
@@ -1149,6 +1150,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1341,6 +1351,20 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -1395,6 +1419,45 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/copy-webpack-plugin": {
       "version": "12.0.2",
@@ -1513,6 +1576,12 @@
       "integrity": "sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -2029,6 +2098,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -2280,6 +2358,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4054,6 +4141,15 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4167,6 +4263,15 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -4306,6 +4411,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -4358,6 +4475,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4480,6 +4623,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4513,6 +4665,12 @@
         "typescript": "*",
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4895,11 +5053,64 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "web-ext-chromium": "npm run watch:chrome & web-ext run -s ./dist/chrome -t chromium",
-    "web-ext-chrome": "npm run watch:chrome & web-ext run -s ./dist/chrome -t chrome",
-    "web-ext-firefox": "npm run watch:firefox & web-ext run -s ./dist/firefox -t firefox-desktop"
+    "web-ext-chromium": "concurrently --kill-others \"npm run watch:chrome\" \"web-ext run -s ./dist/chrome -t chromium\"",
+    "web-ext-firefox": "concurrently --kill-others \"npm run watch:firefox\" \"web-ext run -s ./dist/firefox -t firefox-desktop\""
   },
   "keywords": [],
   "author": "",
@@ -28,6 +27,7 @@
     "@playwright/test": "^1.52.0",
     "@types/chrome": "^0.0.277",
     "@types/node": "^24.7.2",
+    "concurrently": "^9.2.1",
     "copy-webpack-plugin": "^12.0.2",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "watch:firefox": "webpack --config webpack.config.mjs --watch --env browser=firefox",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "web-ext-chromium": "npm run watch:chrome & web-ext run -s ./dist/chrome -t chromium",
+    "web-ext-chrome": "npm run watch:chrome & web-ext run -s ./dist/chrome -t chrome",
+    "web-ext-firefox": "npm run watch:firefox & web-ext run -s ./dist/firefox -t firefox-desktop"
   },
   "keywords": [],
   "author": "",

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -2,9 +2,7 @@
   "manifest_version": 3,
   "version": "0.5.3",
   "name": "PanierClair",
-  "permissions": [
-    "storage"
-  ],
+  "permissions": ["storage"],
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",
@@ -24,13 +22,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "https://www.intermarche.com/*",
-        "https://www.carrefour.fr/*"
-      ],
-      "js": [
-        "content.js"
-      ]
+      "matches": ["https://www.intermarche.com/*", "https://www.carrefour.fr/*"],
+      "js": ["content.js"]
     }
   ],
   "action": {
@@ -42,13 +35,8 @@
   },
   "web_accessible_resources": [
     {
-      "resources": [
-        "assets/*"
-      ],
-      "matches": [
-        "https://www.intermarche.com/*",
-        "https://www.carrefour.fr/*"
-      ]
+      "resources": ["assets/*"],
+      "matches": ["https://www.intermarche.com/*", "https://www.carrefour.fr/*"]
     }
   ]
 }

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -2,9 +2,7 @@
   "manifest_version": 3,
   "version": "0.5.3",
   "name": "PanierClair",
-  "permissions": [
-    "storage"
-  ],
+  "permissions": ["storage"],
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",
@@ -24,13 +22,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "https://www.intermarche.com/*",
-        "https://www.carrefour.fr/*"
-      ],
-      "js": [
-        "content.js"
-      ]
+      "matches": ["https://www.intermarche.com/*", "https://www.carrefour.fr/*"],
+      "js": ["content.js"]
     }
   ],
   "action": {
@@ -42,13 +35,8 @@
   },
   "web_accessible_resources": [
     {
-      "resources": [
-        "assets/*"
-      ],
-      "matches": [
-        "https://www.intermarche.com/*",
-        "https://www.carrefour.fr/*"
-      ]
+      "resources": ["assets/*"],
+      "matches": ["https://www.intermarche.com/*", "https://www.carrefour.fr/*"]
     }
   ]
 }

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,15 +1,9 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "version": "0.5.3",
   "name": "PanierClair",
   "permissions": [
-    "storage",
-    "https://world.openfoodfacts.net/*",
-    "http://127.0.0.1/*",
-    "https://aletheia-server-1038641305939.europe-west9.run.app/*",
-    "http://35.180.111.230:8010/*",
-    "https://www.intermarche.com/*",
-    "https://www.carrefour.fr/"
+    "storage"
   ],
   "icons": {
     "16": "icons/icon-16.png",
@@ -17,11 +11,16 @@
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
+  "host_permissions": [
+    "https://world.openfoodfacts.net/*",
+    "http://127.0.0.1/*",
+    "https://aletheia-server-1038641305939.europe-west9.run.app/*",
+    "http://35.180.111.230:8010/*",
+    "https://www.intermarche.com/*",
+    "https://www.carrefour.fr/"
+  ],
   "background": {
-    "scripts": [
-      "background.js"
-    ],
-    "persistent": false
+    "scripts": ["background.js"]
   },
   "content_scripts": [
     {
@@ -34,7 +33,7 @@
       ]
     }
   ],
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_icon": {
       "16": "icons/icon-16.png",
@@ -42,6 +41,14 @@
     }
   },
   "web_accessible_resources": [
-    "assets/*"
+    {
+      "resources": [
+        "assets/*"
+      ],
+      "matches": [
+        "https://www.intermarche.com/*",
+        "https://www.carrefour.fr/*"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Update to Manifest V3 for Firefox + support web-ext in build process.

See https://github.com/4ntoninFille/PanierClair/issues/34


Only change for Manifest v3 compared to  Chrome one is the syntax for the service worker. 

